### PR TITLE
Set up Spark Java Maven project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target/
+*.class
+*.log
+.idea/
+.vscode/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,77 @@
-# Test
-Practice of GIT HUB
-Tested by Rsaheb
+# Spark Java Project
+
+A minimal Apache Spark project written in Java. It includes a Maven build, a runnable word-count example, unit tests, and a small sample input file.
+
+## Prerequisites
+
+- Java 17 or newer installed
+- Maven 3.9 or newer installed
+- Optional: a local Apache Spark installation if you want to run with `spark-submit`
+
+> This project is configured with Apache Spark `3.5.8` and Scala binary version `2.12` through the `spark-sql_2.12` Maven artifact.
+
+## Project Structure
+
+```text
+.
+├── pom.xml
+├── data/
+│   └── sample.txt
+└── src/
+    ├── main/java/com/example/spark/WordCountApp.java
+    ├── main/java/com/example/spark/WordTokenizer.java
+    └── test/java/com/example/spark/WordTokenizerTest.java
+```
+
+## Build and Test
+
+Run the unit tests:
+
+```bash
+mvn test
+```
+
+Create an executable shaded JAR:
+
+```bash
+mvn package
+```
+
+## Run Locally with Maven
+
+Run the sample word-count job in local mode:
+
+```bash
+mvn exec:java \
+  -Dexec.mainClass=com.example.spark.WordCountApp \
+  -Dexec.args=data/sample.txt \
+  -Dspark.master=local[*]
+```
+
+If your Maven installation does not automatically resolve the Exec Maven Plugin, use the generated JAR instead.
+
+## Run with Java
+
+After packaging, run the shaded JAR directly:
+
+```bash
+java -Dspark.master=local[*] -jar target/spark-java-project-1.0.0-SNAPSHOT.jar data/sample.txt
+```
+
+## Run with spark-submit
+
+If Apache Spark is installed locally and `spark-submit` is on your `PATH`:
+
+```bash
+spark-submit \
+  --class com.example.spark.WordCountApp \
+  --master local[*] \
+  target/spark-java-project-1.0.0-SNAPSHOT.jar \
+  data/sample.txt
+```
+
+## Next Steps
+
+- Replace `WordCountApp` with your real Spark job.
+- Put larger input files outside the repository and pass their path as the first command-line argument.
+- Add more dependencies to `pom.xml` if you need connectors such as Kafka, JDBC, or cloud storage clients.

--- a/data/sample.txt
+++ b/data/sample.txt
@@ -1,0 +1,3 @@
+Hello Spark
+Hello Java
+Spark makes data processing fast

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>spark-java-project</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Spark Java Project</name>
+    <description>A minimal Apache Spark project written in Java.</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>3.5.8</spark.version>
+        <junit.version>5.11.4</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.spark.WordCountApp</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/spark/WordCountApp.java
+++ b/src/main/java/com/example/spark/WordCountApp.java
@@ -1,0 +1,49 @@
+package com.example.spark;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import static org.apache.spark.sql.functions.col;
+
+public final class WordCountApp {
+    private WordCountApp() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.err.println("Usage: spark-submit --class com.example.spark.WordCountApp <jar> <input-path>");
+            System.exit(1);
+        }
+
+        SparkSession spark = createSparkSession();
+
+        try {
+            Dataset<String> lines = spark.read().textFile(args[0]);
+            Dataset<String> words = lines.flatMap(
+                    line -> WordTokenizer.tokenize(line).iterator(),
+                    Encoders.STRING());
+
+            Dataset<Row> counts = words.groupBy(col("value").alias("word"))
+                    .count()
+                    .orderBy(col("count").desc(), col("word"));
+
+            counts.show(false);
+        } finally {
+            spark.stop();
+        }
+    }
+
+    private static SparkSession createSparkSession() {
+        SparkSession.Builder builder = SparkSession.builder()
+                .appName("Spark Java Word Count");
+
+        String master = System.getProperty("spark.master");
+        if (master != null && !master.isBlank()) {
+            builder.master(master);
+        }
+
+        return builder.getOrCreate();
+    }
+}

--- a/src/main/java/com/example/spark/WordTokenizer.java
+++ b/src/main/java/com/example/spark/WordTokenizer.java
@@ -1,0 +1,20 @@
+package com.example.spark;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+public final class WordTokenizer {
+    private WordTokenizer() {
+    }
+
+    public static List<String> tokenize(String line) {
+        if (line == null || line.isBlank()) {
+            return List.of();
+        }
+
+        return Stream.of(line.toLowerCase(Locale.ROOT).split("\\W+"))
+                .filter(token -> !token.isBlank())
+                .toList();
+    }
+}

--- a/src/test/java/com/example/spark/WordTokenizerTest.java
+++ b/src/test/java/com/example/spark/WordTokenizerTest.java
@@ -1,0 +1,21 @@
+package com.example.spark;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class WordTokenizerTest {
+    @Test
+    void tokenizeNormalizesTextIntoWords() {
+        assertEquals(
+                List.of("hello", "spark", "hello", "java"),
+                WordTokenizer.tokenize("Hello, Spark! Hello Java."));
+    }
+
+    @Test
+    void tokenizeIgnoresBlankInput() {
+        assertEquals(List.of(), WordTokenizer.tokenize("   "));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, ready-to-run Apache Spark Java project scaffold so users can build and run a simple word-count job with Maven and Java 17.
- Include a reusable tokenizer and unit tests so the parsing logic can be validated independently of Spark runtime.

### Description
- Add `pom.xml` configured for Java 17, `spark-sql_2.12` (Spark 3.5.8), `junit-jupiter`, `exec-maven-plugin` for local runs, and `maven-shade-plugin` to produce a runnable shaded JAR with main class `com.example.spark.WordCountApp`.
- Add the Spark application `src/main/java/com/example/spark/WordCountApp.java` which builds a `SparkSession`, reads a text file, tokenizes lines, groups and counts words, and prints results.
- Add the tokenizer helper `src/main/java/com/example/spark/WordTokenizer.java` and unit tests `src/test/java/com/example/spark/WordTokenizerTest.java` that validate tokenization and blank input handling.
- Add sample input `data/sample.txt`, `.gitignore`, and an expanded `README.md` with build/run/test instructions and example commands using `mvn`, `java -jar`, and `spark-submit`.

### Testing
- Verified `pom.xml` is well-formed with `python3 -c "import xml.etree.ElementTree as ET; ET.parse('pom.xml')"` which succeeded.
- Verified the helper compiles with `javac --release 17 -d /tmp/spark-java-check src/main/java/com/example/spark/WordTokenizer.java` which succeeded.
- Attempted `mvn test` but the build failed because Maven could not resolve `maven-resources-plugin:3.3.1` from Maven Central (HTTP 403), so unit tests were not executed under Maven in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091ff871748326a13c0aac7a1f1a25)